### PR TITLE
Feat: add a master document for WHO DQ Tool guide

### DIFF
--- a/docs/en/dhis2_who_data_quality_tool_guide.md
+++ b/docs/en/dhis2_who_data_quality_tool_guide.md
@@ -1,0 +1,21 @@
+---
+title: 'DHIS 2 manual for the WHO Data Quality Tool'
+author: 'WHO'
+subauthor: 'in collaboration with HISP UiO'
+date:
+year: 2020
+month: October
+keywords: [DHIS2, WHO]
+commit:
+version: 0.1
+applicable_txt: 'Applicable to version 0.1'
+---
+<!--DHIS2-SECTION-ID:index-->
+
+# Installation and configuration
+
+!INCLUDE "dq-config.md", 1
+
+# Usage and interpretation
+
+!INCLUDE "dq-use.md", 1


### PR DESCRIPTION
This allows the guide to be more easily integrated into the DHIS2 documentation, while allowing the entire document structure to be managed in this repository.